### PR TITLE
Use protocol independent urls

### DIFF
--- a/default.hbs
+++ b/default.hbs
@@ -41,10 +41,10 @@
             <link rel="prerender" href="{{@blog.cover}}" />
             <link rel="prefetch" href="{{@blog.cover}}" />
         {{/if}}
-        <link rel="dns-prefetch" href="http://fonts.googleapis.com/" />
+        <link rel="dns-prefetch" href="//fonts.googleapis.com/" />
 
         {{! Scripts and Stylesheets }}
-        <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=Open+Sans:400,300,600" />
+        <link rel="stylesheet" href="//fonts.googleapis.com/css?family=Open+Sans:400,300,600" />
         <link rel="stylesheet" href="{{asset 'css/basics.css'}}" />
         <link rel="stylesheet" href="{{asset 'css/animate.css'}}" />
         <link rel="stylesheet" href="{{asset 'css/gist.css'}}" />


### PR DESCRIPTION
remove `http://` from urls, so that https sites don't complain about loading insecure content
