### PR TITLE
Add a check for 0.5.2 post image, but with backwards compatibility

### DIFF
--- a/partials/featured.hbs
+++ b/partials/featured.hbs
@@ -1,6 +1,6 @@
 <script>
     var image = document.querySelectorAll("article img:first-child")[0],
-        src = image.src,
+        src = '{{image}}'||image.src, //image.src,
         parent = image.parentNode;
         header = document.getElementsByTagName("header")[0],
         facebook = document.querySelectorAll("meta[property='og:image']")[0],
@@ -8,7 +8,9 @@
     header.style.backgroundImage = 'url(' + src + ')';
     if (facebook) { facebook.setAttribute("content", src); }
     if (twitter) { twitter.setAttribute("content", src); }
-    image.id = "remove-this";
-    var im = document.getElementById("remove-this").parentNode;
-    im.parentNode.removeChild(im);
+    if(src==image.src){
+        image.id = "remove-this";
+        var im = document.getElementById("remove-this").parentNode;
+        im.parentNode.removeChild(im);
+    }
 </script>


### PR DESCRIPTION
A simple update to grab the post image from v 0.5.2 of ghost.  I haven't checked compatibility with previous versions of ghost.
