### PR TITLE
Move .excerpt behind elements by setting z-index:-1, preventing hiding o...

### DIFF
--- a/assets/css/phantom.css
+++ b/assets/css/phantom.css
@@ -91,6 +91,10 @@ a:hover {
 strong {
 	font-weight:600;
 }
+.excerpt {
+	z-index:-1;
+	position:relative;
+}
 .container, .pagination {
 	position:relative;
 	width:500px;


### PR DESCRIPTION
Since the excerpt is the full width of the screen, it will overlap some tags. Negative z-index and relative position moves it behind the tags. Reference error #16 

Checked on Chrome Version 36.0.1985.125, Firefox Version 33.1.1, IE11 and Chrome on Android Version 39.0.2171.59
